### PR TITLE
notebooks: fixing image refs

### DIFF
--- a/notebooks/1.0 - jupyter dashboard.ipynb
+++ b/notebooks/1.0 - jupyter dashboard.ipynb
@@ -25,7 +25,7 @@
     "\n",
     "The main goal of this dashboard is to list all your **notebooks**, **files** and **folders**. \n",
     "\n",
-    "<img src=\"Data/static/jupyter_notebooks/jupyter_dashboard.png\" >"
+    "<img src=\"static/jupyter_notebooks/jupyter_dashboard.png\" >"
    ]
   },
   {

--- a/notebooks/1.1 - jupyter not a book.ipynb
+++ b/notebooks/1.1 - jupyter not a book.ipynb
@@ -25,7 +25,7 @@
     "\n",
     "The notebook can be divided into 3 parts:\n",
     "    \n",
-    "<img src='Data/static/jupyter_notebooks/presentation_of_notebook.png' /> \n",
+    "<img src='static/jupyter_notebooks/presentation_of_notebook.png' /> \n",
     "    \n",
     "    "
    ]
@@ -62,7 +62,7 @@
     "\n",
     " **Help > User Interactive Tour**\n",
     " \n",
-    "<img src='Data/static/jupyter_notebooks/help_user_interface.gif' />\n",
+    "<img src='static/jupyter_notebooks/help_user_interface.gif' />\n",
     " \n",
     " \n",
     " "
@@ -169,7 +169,7 @@
    "source": [
     "Edit mode is indicated by a green cell border\n",
     "\n",
-    "<img src='Data/static/jupyter_notebooks/edit_mode.png' />\n",
+    "<img src='static/jupyter_notebooks/edit_mode.png' />\n",
     "\n",
     "When a cell is in **edit mode**, you can type into the cell like a normal cell editor."
    ]
@@ -211,7 +211,7 @@
    "source": [
     "This mode is indicated by a blue cell border\n",
     "\n",
-    "<img src='Data/static/jupyter_notebooks/command_mode.png' />"
+    "<img src='static/jupyter_notebooks/command_mode.png' />"
    ]
   },
   {
@@ -467,7 +467,7 @@
     " or\n",
     " - click the cell and select **markdown** from the toolbar\n",
     " \n",
-    "<img src='Data/static/jupyter_notebooks/cell_in_markdown.gif' />\n",
+    "<img src='static/jupyter_notebooks/cell_in_markdown.gif' />\n",
     " \n",
     " \n",
     "To turn it back into a python cell (default cell):\n",
@@ -476,7 +476,7 @@
     " or\n",
     " - click the cell and select **code** from the toolbar\n",
     " \n",
-    "<img src='Data/static/jupyter_notebooks/cell_in_code.gif' />\n",
+    "<img src='static/jupyter_notebooks/cell_in_code.gif' />\n",
     " \n",
     " "
    ]

--- a/notebooks/1.2 - markdown syntax.ipynb
+++ b/notebooks/1.2 - markdown syntax.ipynb
@@ -352,7 +352,7 @@
     "\n",
     "For example, in the images folder, we have the Python logo:\n",
     "\n",
-    "<img src=\"Data/static/jupyter_notebooks/python_logo.png\" />\n",
+    "<img src=\"static/jupyter_notebooks/python_logo.png\" />\n",
     "\n",
     "These do not embed the data into the notebook file, and require that the files exist when you are viewing the notebook."
    ]

--- a/notebooks/1.3 - introduction to python.ipynb
+++ b/notebooks/1.3 - introduction to python.ipynb
@@ -155,7 +155,7 @@
    "source": [
     "If there is only one skill you need to take from this training is learn to use google search to find how to use a python command. Use this skill to  display the following statement.\n",
     "\n",
-    "<img src='Data/static/python_introduction/format_exercise.png' />\n",
+    "<img src='static/python_introduction/format_exercise.png' />\n",
     "\n",
     "\n"
    ]

--- a/notebooks/7 - widgets.ipynb
+++ b/notebooks/7 - widgets.ipynb
@@ -2,7 +2,6 @@
  "cells": [
   {
    "cell_type": "code",
-
    "execution_count": 8,
    "metadata": {
     "run_control": {
@@ -10,7 +9,6 @@
      "read_only": false
     }
    },
-
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -56,7 +54,6 @@
   },
   {
    "cell_type": "code",
-
    "execution_count": 22,
    "metadata": {
     "run_control": {
@@ -64,7 +61,6 @@
      "read_only": false
     }
    },
-
    "outputs": [
     {
      "data": {
@@ -125,7 +121,6 @@
   },
   {
    "cell_type": "code",
-
    "execution_count": 23,
    "metadata": {
     "run_control": {
@@ -134,7 +129,6 @@
     }
    },
    "outputs": [],
-
    "source": [
     "from IPython.html.widgets import interact\n",
     "from IPython.html import widgets"
@@ -142,7 +136,6 @@
   },
   {
    "cell_type": "code",
-
    "execution_count": 24,
    "metadata": {
     "run_control": {
@@ -150,7 +143,6 @@
      "read_only": false
     }
    },
-
    "outputs": [
     {
      "data": {
@@ -216,7 +208,7 @@
     "\n",
     "Only the sky is the limit!\n",
     "\n",
-    "<img src='Data/static/widgets/complex_notebook_with_widgets.png' />"
+    "<img src='static/widgets/complex_notebook_with_widgets.png' />"
    ]
   },
   {

--- a/notebooks/static
+++ b/notebooks/static
@@ -1,0 +1,1 @@
+/EXAMPLES/IPythonNotebookTutorial/Data/static


### PR DESCRIPTION
@JeanBilheux 

The references in the images are currently assuming "Data" folder is around. But the students will only copy the "student"-version of the notebooks, and will not copy the Data folder. So a symbolic link "static" to /EXAMPLES/IPythonNotebookTutorial/Data/static was added into "notebooks" folder. The references are accordingly modified.

See also #22 